### PR TITLE
fix(rules/typescript.js): fix @typescript-eslint/array-type rule

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -1,6 +1,6 @@
 module.exports = {
   rules: {
-    '@typescript-eslint/array-type': ['error', 'array-simple'],
+    '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
     '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
     // Code should be formatted using Prettier.
     '@typescript-eslint/func-call-spacing': 'off',


### PR DESCRIPTION
Passing object to @typescript-eslint/array-type rule otherwise eslint fails trying to load config,
since is expecting an object instead of an string.

fix #127