### PR TITLE
feat: ignore magic-number -1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridedott/eslint-config",
-  "version": "0.4.75",
+  "version": "0.4.76",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -57,5 +57,5 @@
     "format": "prettier --check \"**/*.{js,json,md,ts,yml,yaml}\"",
     "format:fix": "prettier --write \"**/*.{js,json,md,ts,yml,yaml}\""
   },
-  "version": "0.4.75"
+  "version": "0.4.76"
 }

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -19,7 +19,7 @@ module.exports = {
     '@typescript-eslint/no-inferrable-types': 'off',
     '@typescript-eslint/no-magic-numbers': [
       'error',
-      { ignore: [0, 1], ignoreNumericLiteralTypes: true },
+      { ignore: [-1, 0, 1], ignoreNumericLiteralTypes: true },
     ],
     /*
      * Custom objects are often used in class-free applications.


### PR DESCRIPTION
To be able to use the `Array.sort` function we should ignore the magic number `-1`. This PR fixes that