### PR TITLE
feat: add missing typescript-eslint rules

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -1,14 +1,15 @@
 module.exports = {
   rules: {
     '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
-    '@typescript-eslint/ban-ts-comment': 'error',
     '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
+    /**
+     * Formatting should be done by Prettier.
+     */
     '@typescript-eslint/comma-spacing': 'off',
     '@typescript-eslint/explicit-function-return-type': [
       'error',
       { allowTypedFunctionExpressions: false },
     ],
-    '@typescript-eslint/explicit-module-boundary-types': 'error',
     // Code should be formatted using Prettier.
     '@typescript-eslint/func-call-spacing': 'off',
     '@typescript-eslint/generic-type-naming': ['error', '^[A-Z][a-zA-Z]+$'],
@@ -18,7 +19,6 @@ module.exports = {
      * TODO (oleg-koval) [2020-01-29] Enable and configure this rule after alignment.
      */
     '@typescript-eslint/naming-convention': 'off',
-    '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
     '@typescript-eslint/no-dynamic-delete': 'error',
     // Empty functions are often used as no operation.
     '@typescript-eslint/no-empty-function': 'off',
@@ -60,7 +60,6 @@ module.exports = {
       'error',
       { ignoreRestSiblings: true },
     ],
-    '@typescript-eslint/prefer-as-const': 'error',
     '@typescript-eslint/prefer-optional-chain': ['error'],
     '@typescript-eslint/prefer-nullish-coalescing': [
       'error',

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -1,11 +1,14 @@
 module.exports = {
   rules: {
     '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
+    '@typescript-eslint/ban-ts-comment': 'error',
     '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
+    '@typescript-eslint/comma-spacing': 'off',
     '@typescript-eslint/explicit-function-return-type': [
       'error',
       { allowTypedFunctionExpressions: false },
     ],
+    '@typescript-eslint/explicit-module-boundary-types': 'error',
     // Code should be formatted using Prettier.
     '@typescript-eslint/func-call-spacing': 'off',
     '@typescript-eslint/generic-type-naming': ['error', '^[A-Z][a-zA-Z]+$'],
@@ -15,6 +18,7 @@ module.exports = {
      * TODO (oleg-koval) [2020-01-29] Enable and configure this rule after alignment.
      */
     '@typescript-eslint/naming-convention': 'off',
+    '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
     '@typescript-eslint/no-dynamic-delete': 'error',
     // Empty functions are often used as no operation.
     '@typescript-eslint/no-empty-function': 'off',
@@ -47,11 +51,16 @@ module.exports = {
       'error',
       { allowConstantLoopConditions: false, ignoreRhs: true },
     ],
-    '@typescript-eslint/no-untyped-public-signature': 'error',
+    /**
+     * This rule has been deprecated and replaced by
+     * explicit-module-boundary-types as of v2.17.0.
+     */
+    '@typescript-eslint/no-untyped-public-signature': 'off',
     '@typescript-eslint/no-unused-vars': [
       'error',
       { ignoreRestSiblings: true },
     ],
+    '@typescript-eslint/prefer-as-const': 'error',
     '@typescript-eslint/prefer-optional-chain': ['error'],
     '@typescript-eslint/prefer-nullish-coalescing': [
       'error',

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -53,7 +53,7 @@ module.exports = {
     ],
     /**
      * This rule has been deprecated and replaced by
-     * explicit-module-boundary-types as of v2.17.0.
+     * explicit-module-boundary-types as of @typescript-eslint/* v2.17.0.
      */
     '@typescript-eslint/no-untyped-public-signature': 'off',
     '@typescript-eslint/no-unused-vars': [


### PR DESCRIPTION
This concerns rules added in  [v2.17.0](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/CHANGELOG.md#2170-2020-01-20) and [v2.18.0](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/CHANGELOG.md#2180-2020-01-27) of https://github.com/typescript-eslint/typescript-eslint/