### PR TITLE
chore: configure jest/prefer-expect-assertions

### DIFF
--- a/rules/jest.js
+++ b/rules/jest.js
@@ -8,5 +8,6 @@ module.exports = {
     'jest/require-top-level-describe': 'off',
     'jest/prefer-called-with': 'off',
     'jest/prefer-inline-snapshots': 'off',
+    'jest/prefer-expect-assertions': 'error',
   },
 };

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -708,24 +708,6 @@ exports[`jest rules jest/prefer-expect-assertions should fail on an invalid fixt
 Array [
   Object {
     "column": 1,
-    "endColumn": 5,
-    "endLine": 1,
-    "fix": Object {
-      "range": Array [
-        0,
-        4,
-      ],
-      "text": "it",
-    },
-    "line": 1,
-    "message": "Prefer using 'it' instead of 'test'",
-    "messageId": "consistentMethod",
-    "nodeType": "Identifier",
-    "ruleId": "jest/consistent-test-it",
-    "severity": 2,
-  },
-  Object {
-    "column": 1,
     "endColumn": 3,
     "endLine": 4,
     "line": 1,
@@ -736,8 +718,8 @@ Array [
     "severity": 2,
   },
   Object {
-    "column": 17,
-    "endColumn": 22,
+    "column": 15,
+    "endColumn": 20,
     "endLine": 1,
     "line": 1,
     "message": "Missing return type on function.",
@@ -752,8 +734,8 @@ Array [
     "endLine": 3,
     "fix": Object {
       "range": Array [
-        62,
-        69,
+        60,
+        67,
       ],
       "text": "toStrictEqual",
     },
@@ -762,24 +744,6 @@ Array [
     "messageId": "useToStrictEqual",
     "nodeType": "Identifier",
     "ruleId": "jest/prefer-strict-equal",
-    "severity": 2,
-  },
-  Object {
-    "column": 1,
-    "endColumn": 5,
-    "endLine": 6,
-    "fix": Object {
-      "range": Array [
-        83,
-        87,
-      ],
-      "text": "it",
-    },
-    "line": 6,
-    "message": "Prefer using 'it' instead of 'test'",
-    "messageId": "consistentMethod",
-    "nodeType": "Identifier",
-    "ruleId": "jest/consistent-test-it",
     "severity": 2,
   },
   Object {
@@ -794,8 +758,8 @@ Array [
     "severity": 2,
   },
   Object {
-    "column": 6,
-    "endColumn": 15,
+    "column": 4,
+    "endColumn": 13,
     "endLine": 6,
     "line": 6,
     "message": "Test title is used multiple times in the same describe block.",
@@ -805,8 +769,8 @@ Array [
     "severity": 2,
   },
   Object {
-    "column": 17,
-    "endColumn": 22,
+    "column": 15,
+    "endColumn": 20,
     "endLine": 6,
     "line": 6,
     "message": "Missing return type on function.",

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -704,6 +704,120 @@ Array [
 ]
 `;
 
+exports[`jest rules jest/prefer-expect-assertions should fail on an invalid fixture 1`] = `
+Array [
+  Object {
+    "column": 1,
+    "endColumn": 5,
+    "endLine": 1,
+    "fix": Object {
+      "range": Array [
+        0,
+        4,
+      ],
+      "text": "it",
+    },
+    "line": 1,
+    "message": "Prefer using 'it' instead of 'test'",
+    "messageId": "consistentMethod",
+    "nodeType": "Identifier",
+    "ruleId": "jest/consistent-test-it",
+    "severity": 2,
+  },
+  Object {
+    "column": 1,
+    "endColumn": 3,
+    "endLine": 4,
+    "line": 1,
+    "message": "Every test should have either \`expect.assertions(<number of assertions>)\` or \`expect.hasAssertions()\` as its first expression",
+    "messageId": "haveExpectAssertions",
+    "nodeType": "CallExpression",
+    "ruleId": "jest/prefer-expect-assertions",
+    "severity": 2,
+  },
+  Object {
+    "column": 17,
+    "endColumn": 22,
+    "endLine": 1,
+    "line": 1,
+    "message": "Missing return type on function.",
+    "messageId": "missingReturnType",
+    "nodeType": "ArrowFunctionExpression",
+    "ruleId": "@typescript-eslint/explicit-function-return-type",
+    "severity": 2,
+  },
+  Object {
+    "column": 13,
+    "endColumn": 20,
+    "endLine": 3,
+    "fix": Object {
+      "range": Array [
+        62,
+        69,
+      ],
+      "text": "toStrictEqual",
+    },
+    "line": 3,
+    "message": "Use toStrictEqual() instead",
+    "messageId": "useToStrictEqual",
+    "nodeType": "Identifier",
+    "ruleId": "jest/prefer-strict-equal",
+    "severity": 2,
+  },
+  Object {
+    "column": 1,
+    "endColumn": 5,
+    "endLine": 6,
+    "fix": Object {
+      "range": Array [
+        83,
+        87,
+      ],
+      "text": "it",
+    },
+    "line": 6,
+    "message": "Prefer using 'it' instead of 'test'",
+    "messageId": "consistentMethod",
+    "nodeType": "Identifier",
+    "ruleId": "jest/consistent-test-it",
+    "severity": 2,
+  },
+  Object {
+    "column": 1,
+    "endColumn": 3,
+    "endLine": 8,
+    "line": 6,
+    "message": "Every test should have either \`expect.assertions(<number of assertions>)\` or \`expect.hasAssertions()\` as its first expression",
+    "messageId": "haveExpectAssertions",
+    "nodeType": "CallExpression",
+    "ruleId": "jest/prefer-expect-assertions",
+    "severity": 2,
+  },
+  Object {
+    "column": 6,
+    "endColumn": 15,
+    "endLine": 6,
+    "line": 6,
+    "message": "Test title is used multiple times in the same describe block.",
+    "messageId": "multipleTestTitle",
+    "nodeType": "Literal",
+    "ruleId": "jest/no-identical-title",
+    "severity": 2,
+  },
+  Object {
+    "column": 17,
+    "endColumn": 22,
+    "endLine": 6,
+    "line": 6,
+    "message": "Missing return type on function.",
+    "messageId": "missingReturnType",
+    "nodeType": "ArrowFunctionExpression",
+    "ruleId": "@typescript-eslint/explicit-function-return-type",
+    "severity": 2,
+  },
+]
+`;
+
 exports[`overrides rules max-len should fail on an invalid fixture 1`] = `
 Array [
   Object {

--- a/test/fixtures/jest/prefer-expect-assertions.fail.ts
+++ b/test/fixtures/jest/prefer-expect-assertions.fail.ts
@@ -1,8 +1,8 @@
-test("my test", () => {
-  expect.assertions("1");
-  expect(1).toEqual("foo");
+test('my test', () => {
+  expect.assertions('1');
+  expect(1).toEqual('foo');
 });
 
-test("my test", () => {
-  expect(1).toStrictEqual("foo");
+test('my test', () => {
+  expect(1).toStrictEqual('foo');
 });

--- a/test/fixtures/jest/prefer-expect-assertions.fail.ts
+++ b/test/fixtures/jest/prefer-expect-assertions.fail.ts
@@ -1,0 +1,8 @@
+test("my test", () => {
+  expect.assertions("1");
+  expect(1).toEqual("foo");
+});
+
+test("my test", () => {
+  expect(1).toStrictEqual("foo");
+});

--- a/test/fixtures/jest/prefer-expect-assertions.fail.ts
+++ b/test/fixtures/jest/prefer-expect-assertions.fail.ts
@@ -1,8 +1,8 @@
-test('my test', () => {
+it('my test', () => {
   expect.assertions('1');
   expect(1).toEqual('foo');
 });
 
-test('my test', () => {
+it('my test', () => {
   expect(1).toStrictEqual('foo');
 });

--- a/test/fixtures/jest/prefer-expect-assertions.pass.ts
+++ b/test/fixtures/jest/prefer-expect-assertions.pass.ts
@@ -1,0 +1,9 @@
+it('my test', (): void => {
+  expect.assertions(1);
+  expect(1).toStrictEqual('foo');
+});
+
+it('my test 2', (): void => {
+  expect.hasAssertions();
+  expect(1).toStrictEqual('foo');
+});


### PR DESCRIPTION
### Motivation
This is often useful when testing asynchronous code, in order to make sure that assertions in a callback actually got called but also for consistency across tests.