### PR TITLE
fix: disable native init-declarations rule

### DIFF
--- a/rules/eslint.js
+++ b/rules/eslint.js
@@ -82,5 +82,7 @@ module.exports = {
     semi: 'off',
     // This is handled by simple-import-sort plugin.
     'sort-imports': 'off',
+    // This is handled by typescript-eslint plugin.
+    'init-declarations': 'off',
   },
 };


### PR DESCRIPTION
Disabling the native `init-declarations` as this has been replaced by `@typescript-eslint/init-declarations`.

The new `@typescript-eslint/init-declarations` is error and not warn tho.