### PR TITLE
feat: disable @typescript-eslint/no-confusing-void-expression rule

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -168,10 +168,10 @@ module.exports = {
       },
     ],
     /**
-     * Somehow this rule is reported before using
-     * @typescript-eslint/eslint-plugin V4.7.0 (where it was added), see
-     * https://github.com/typescript-eslint/typescript-eslint/releases/tag/v4.7.0
-     * https://github.com/ridedott/fastwheel-service/pull/339/checks?check_run_id=1390826071.
+     * TODO [@typescript-eslint/eslint-plugin@>=4.7.0] (@ridedott/platform)
+     * Somehow this rule is reported before using current version (4.6.1)
+     * enable it when upgrading to V4.7.0, see
+     * https://github.com/typescript-eslint/typescript-eslint/releases/tag/v4.7.0.
      */
     '@typescript-eslint/no-confusing-void-expression': 'off',
     '@typescript-eslint/no-dynamic-delete': 'error',

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -167,6 +167,13 @@ module.exports = {
         selector: 'variable',
       },
     ],
+    /**
+     * Somehow this rule is reported before using
+     * @typescript-eslint/eslint-plugin V4.7.0 (where it was added), see
+     * https://github.com/typescript-eslint/typescript-eslint/releases/tag/v4.7.0
+     * https://github.com/ridedott/fastwheel-service/pull/339/checks?check_run_id=1390826071.
+     */
+    '@typescript-eslint/no-confusing-void-expression': 'off',
     '@typescript-eslint/no-dynamic-delete': 'error',
     // Empty functions are often used as no operation.
     '@typescript-eslint/no-empty-function': 'off',


### PR DESCRIPTION
Seems that the `@typescript-eslint/no-confusing-void-expression` rule is being reported even before being present in the version of `@typescript-eslint/eslint-plugin` used in this package (V4.6.1).  The rule was introduced in [V4.7.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v4.7.0). 
See here for an example of this happening: https://github.com/ridedott/fastwheel-service/pull/339/checks?check_run_id=1390826071