### PR TITLE
feat: do not push a release in ci on chore release messages

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release:
+    if: contains(github.event.commits[0].message, 'chore(release)') == false
     name: Release
     runs-on: ubuntu-latest
     steps:
@@ -54,3 +55,4 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         name: Publish to npm
         run: npm publish
+    timeout-minutes: 10


### PR DESCRIPTION
CI fails for chore(release) messages because the package is already published. This prevents a re-release.

As copied [from firestore-schema](https://github.com/ridedott/firestore-schema/blob/f177809df58540237afba82af4905b70e74616c0/.github/workflows/continuous-delivery.yaml#L10).