### PR TITLE
feat: ignore cspell and c8 block comments for capitalized-comments rule

### DIFF
--- a/rules/eslint.js
+++ b/rules/eslint.js
@@ -2,7 +2,11 @@ module.exports = {
   rules: {
     // This is covered by @typescript-eslint/camelcase rule.
     camelcase: 'off',
-    'capitalized-comments': ['error', 'always', { block: { ignorePattern: 'cspell|c8' } }],
+    'capitalized-comments': [
+      'error',
+      'always',
+      { block: { ignorePattern: 'cspell|c8' } },
+    ],
     // TypeScript will always make sure return values are correct.
     'consistent-return': 'off',
     // Duplicate of @typescript-eslint/dot-notation.

--- a/rules/eslint.js
+++ b/rules/eslint.js
@@ -2,7 +2,7 @@ module.exports = {
   rules: {
     // This is covered by @typescript-eslint/camelcase rule.
     camelcase: 'off',
-    'capitalized-comments': ['error', 'always', { ignorePattern: 'cspell' }],
+    'capitalized-comments': ['error', 'always', { block: { ignorePattern: 'cspell|c8' } }],
     // TypeScript will always make sure return values are correct.
     'consistent-return': 'off',
     // Duplicate of @typescript-eslint/dot-notation.

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -159,6 +159,42 @@ Array [
     "ruleId": "capitalized-comments",
     "severity": 2,
   },
+  Object {
+    "column": 1,
+    "endColumn": 22,
+    "endLine": 3,
+    "fix": Object {
+      "range": Array [
+        25,
+        26,
+      ],
+      "text": "C",
+    },
+    "line": 3,
+    "message": "Comments should not begin with a lowercase character.",
+    "messageId": "unexpectedLowercaseComment",
+    "nodeType": null,
+    "ruleId": "capitalized-comments",
+    "severity": 2,
+  },
+  Object {
+    "column": 1,
+    "endColumn": 20,
+    "endLine": 5,
+    "fix": Object {
+      "range": Array [
+        48,
+        49,
+      ],
+      "text": "C",
+    },
+    "line": 5,
+    "message": "Comments should not begin with a lowercase character.",
+    "messageId": "unexpectedLowercaseComment",
+    "nodeType": null,
+    "ruleId": "capitalized-comments",
+    "severity": 2,
+  },
 ]
 `;
 

--- a/test/fixtures/eslint/capitalized-comments.fail.ts
+++ b/test/fixtures/eslint/capitalized-comments.fail.ts
@@ -1,1 +1,5 @@
 // lowercase comment
+
+// cspell ignore:this
+
+// c8 ignore next 4

--- a/test/fixtures/eslint/capitalized-comments.pass.ts
+++ b/test/fixtures/eslint/capitalized-comments.pass.ts
@@ -9,3 +9,11 @@
 /**
  * 丈 Non-Latin character at beginning of comment
  */
+
+/**
+ * cspell ignore:this
+ */
+
+/* cspell ignore:this */
+
+/* c8 ignore next 4 */


### PR DESCRIPTION
This also removes the usage of `// cspell ...` to enforce it as block comments.