### PR TITLE
revert: perf: do not detect cycles in dependencies

### DIFF
--- a/rules/import.js
+++ b/rules/import.js
@@ -2,7 +2,7 @@ module.exports = {
   rules: {
     // This rule conflicts with features provided by TypeScript.
     'import/namespace': 'off',
-    'import/no-cycle': ['error', { ignoreExternal: true, maxDepth: Infinity }],
+    'import/no-cycle': ['error', { maxDepth: Infinity }],
     'import/no-default-export': 'error',
     'import/no-self-import': 'error',
   },


### PR DESCRIPTION
This reverts commit 7cbf043d241f88a85f722b567f692662dab879cb.

I don't necessarily mean to revert the commit, but wanted to share my findings and maybe start the discussion. 

Like I [posted](https://ridedott.slack.com/archives/CDW5BKQJ1/p1629450455098700) in development-back-end channel, some recent change to `@ridedott/eslint-config` made Portal Lint check run [very slowly](https://github.com/ridedott/portal/pull/4160/checks?check_run_id=3382612441): going from ~2.2m to ~13-18m 😱  This looked like too big of a leap that could be caused by some @typescript-eslint double-parsing, so I decided to investigate more.

Running ESLint in profiling mode on my local machine revealed that the biggest part of it is `import/no-cycle` rule:
Before: ~35s After ~750s

I looked up the implementation of the rule and compared with the recent changes in `@ridedott/eslint-config`. The [recent change](https://github.com/ridedott/eslint-config/pull/998) was `ignoreExternal: true`, so I looked into that, and locally profiled the only place where this option is used: [here](https://github.com/import-js/eslint-plugin-import/blob/9485c8300dbf17047804adf9529dce21d64db0f5/src/rules/no-cycle.js#L45). So when the `ignoreExternal` is set to true, the rule also runs some function `isExternal` which does quite a lof of stuff.

Those were the results:
`ignoreExternal: false` (before, default)
```
> TIMING=1 eslint --cache --cache-location='./.cache/eslint' --cache-strategy=content 'src/**/*.{js,jsx,ts,tsx}'

Rule                                            | Time (ms) | Relative
:-----------------------------------------------|----------:|--------:
import/no-cycle                                 | 35293.026 |    60.8%
@typescript-eslint/no-implied-eval              |  4488.052 |     7.7%
import/order                                    |  3355.920 |     5.8%
@typescript-eslint/no-confusing-void-expression |  3231.111 |     5.6%
@typescript-eslint/promise-function-async       |  2938.385 |     5.1%
@typescript-eslint/no-redeclare                 |  1353.640 |     2.3%
@typescript-eslint/no-misused-promises          |   869.993 |     1.5%
jest/unbound-method                             |   848.613 |     1.5%
import/no-self-import                           |   481.450 |     0.8%
padding-line-between-statements                 |   382.271 |     0.7%
Should ignore took:  40.86579895764589 (ms)
```

`ignoreExternal: true` (after)
```
> TIMING=1 eslint --cache --cache-location='./.cache/eslint' --cache-strategy=content 'src/**/*.{js,jsx,ts,tsx}'

Rule                                            |  Time (ms) | Relative
:-----------------------------------------------|-----------:|--------:
import/no-cycle                                 | 752255.525 |    97.0%
@typescript-eslint/no-implied-eval              |   4773.735 |     0.6%
@typescript-eslint/no-confusing-void-expression |   3329.918 |     0.4%
import/order                                    |   3079.554 |     0.4%
@typescript-eslint/promise-function-async       |   2957.068 |     0.4%
@typescript-eslint/no-redeclare                 |   1874.364 |     0.2%
jest/unbound-method                             |    862.337 |     0.1%
@typescript-eslint/no-misused-promises          |    848.206 |     0.1%
import/no-self-import                           |    440.298 |     0.1%
padding-line-between-statements                 |    366.324 |     0.0%
Should ignore took:  727131.469761245 (ms)
```

So for Portal deciding whether to ignore the module takes 97% ot the Lint time which is currently more than 12 minutes to decide whether to ignore the module, which is a lot more than just doing the no-cycle check including it (around 2-3 minutes on CI, locally probably even faster).

I don't necessarily suggest that we should revert this change, because I don't know how this change affected other repos as the original PR that introduced it doesn't have any info on whether the performance actually improved. I can of course just revert this for Portal in its local .eslintc, but thought that it would be valuable to share my findings as it's possible that other projects could encounter this problem as well (maybe frontend apps especially? or it's just Portal that maybe is poorly structured or too big? not sure 🙂 )

WDYT?