### PR TITLE
fix: disable no-restricted-imports temporarily

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -291,4 +291,7 @@ module.exports = {
     // Extended by jest/unbound-method.
     '@typescript-eslint/unbound-method': 'off',
   },
+  // TODO (rustyb) [2021-11-01]: Temporarly disable this rule as empty config causes an error
+  // fixed in typscript-eslint but not released yet
+  '@typescript-eslint/no-restricted-imports': 'off',
 };


### PR DESCRIPTION
Working through dependency updates over the last few days I've noticed that a number of pull requests updating `@ridedott/eslint-config` have all failed for the same reason.

```
TypeError: Error while loading rule '@typescript-eslint/no-restricted-imports': Cannot convert undefined or null to object
```
I did a bit of digging and it would seem this error is related to a bug in `typescript-eslint` which causes the rule to fail falsely when no configuration is suppled to the rule `@typescript-eslint/no-restricted-imports`. The issue has been fixed at https://github.com/typescript-eslint/typescript-eslint/issues/3933. 

I see that it's already been disabled in one ridedott repo - https://github.com/ridedott/web-library/blob/e30fb5ac137f8f77db64403a3941d6fc8854e985/.eslintrc.yaml#L54-L56

While the fix has been merged in `typescript-eslint` it hasn't made it into the last release therefore I propose we add temporary fix here and revert when the fix is released? This would stop us from needing to add a rule to the .eslintrc.yaml file in each repo effected.
