### PR TITLE
feat: add import/no-extraneous-dependencies rule

### DIFF
--- a/rules/import.js
+++ b/rules/import.js
@@ -5,5 +5,14 @@ module.exports = {
     'import/no-cycle': ['error', { maxDepth: Infinity }],
     'import/no-default-export': 'error',
     'import/no-self-import': 'error',
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: false,
+        optionalDependencies: false,
+        peerDependencies: false,
+        bundledDependencies: false,
+      },
+    ],
   },
 };

--- a/rules/import.js
+++ b/rules/import.js
@@ -15,7 +15,7 @@ module.exports = {
           'test/',
         ],
         optionalDependencies: false,
-        peerDependencies: false,
+        peerDependencies: true,
         bundledDependencies: false,
       },
     ],

--- a/rules/import.js
+++ b/rules/import.js
@@ -8,7 +8,12 @@ module.exports = {
     'import/no-extraneous-dependencies': [
       'error',
       {
-        devDependencies: false,
+        devDependencies: [
+          '**/*.spec.ts',
+          '**/__tests__/**',
+          '**/__mocks__/**',
+          'test/',
+        ],
         optionalDependencies: false,
         peerDependencies: false,
         bundledDependencies: false,

--- a/rules/import.js
+++ b/rules/import.js
@@ -15,7 +15,6 @@ module.exports = {
           'test/',
         ],
         optionalDependencies: false,
-        peerDependencies: true,
         bundledDependencies: false,
       },
     ],

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -691,6 +691,21 @@ Array [
 ]
 `;
 
+exports[`import rules import/no-extraneous-dependencies fails on an invalid fixture 1`] = `
+Array [
+  Object {
+    "column": 1,
+    "endColumn": 39,
+    "endLine": 1,
+    "line": 1,
+    "message": "'npm-run-all' should be listed in the project's dependencies, not devDependencies.",
+    "nodeType": "ExportAllDeclaration",
+    "ruleId": "import/no-extraneous-dependencies",
+    "severity": 2,
+  },
+]
+`;
+
 exports[`import rules import/no-self-import fails on an invalid fixture 1`] = `
 Array [
   Object {

--- a/test/fixtures/import/no-extraneous-dependencies.fail.ts
+++ b/test/fixtures/import/no-extraneous-dependencies.fail.ts
@@ -1,0 +1,1 @@
+export * as plugin from 'npm-run-all';

--- a/test/fixtures/import/no-extraneous-dependencies.pass.ts
+++ b/test/fixtures/import/no-extraneous-dependencies.pass.ts
@@ -1,0 +1,1 @@
+export * as plugin from '@ridedott/eslint-plugin';


### PR DESCRIPTION
Currently it is possible to import a devDependency without any build errors.
It only pops out during runtime, like it happened with `payments-service`: https://cloudlogging.app.goo.gl/qyKLJNVRn8xfp1ze7