### PR TITLE
feat: add more paths to ignore devDependencies usage

### DIFF
--- a/rules/import.js
+++ b/rules/import.js
@@ -12,6 +12,8 @@ module.exports = {
           '**/*.spec.ts',
           '**/__tests__/**',
           '**/__mocks__/**',
+          'monitoring/**',
+          'scripts/**',
           'test/**',
         ],
         optionalDependencies: false,


### PR DESCRIPTION
Relates to https://github.com/ridedott/firestore-schema/pull/2690

Clearly `scripts` should also be allowed to use dev dependencies:
https://github.com/ridedott/firestore-schema/runs/4924459667?check_suite_focus=true