### PR TITLE
chore: add missing tests

### DIFF
--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -4046,14 +4046,21 @@ Array [
 exports[`unicorn rules unicorn/prefer-query-selector fails on an invalid fixture 1`] = `
 Array [
   Object {
-    "column": 32,
-    "endColumn": 38,
-    "endLine": 7,
-    "line": 7,
-    "message": "Unexpected use of '<<'.",
-    "messageId": "unexpected",
-    "nodeType": "BinaryExpression",
-    "ruleId": "no-bitwise",
+    "column": 10,
+    "endColumn": 24,
+    "endLine": 1,
+    "fix": Object {
+      "range": Array [
+        9,
+        29,
+      ],
+      "text": "querySelector(\\"#foo\\"",
+    },
+    "line": 1,
+    "message": "Prefer \`.querySelector()\` over \`.getElementById()\`.",
+    "messageId": "prefer-query-selector",
+    "nodeType": "Identifier",
+    "ruleId": "unicorn/prefer-query-selector",
     "severity": 2,
   },
 ]

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -4054,7 +4054,7 @@ Array [
         9,
         29,
       ],
-      "text": "querySelector(\\"#foo\\"",
+      "text": "querySelector('#foo'",
     },
     "line": 1,
     "message": "Prefer \`.querySelector()\` over \`.getElementById()\`.",

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -1640,15 +1640,28 @@ Array [
 exports[`typescriptEslint rules @typescript-eslint/prefer-nullish-coalescing fails on an invalid fixture 1`] = `
 Array [
   Object {
-    "column": 32,
-    "endColumn": 38,
-    "endLine": 8,
-    "line": 8,
-    "message": "Unexpected use of '<<'.",
-    "messageId": "unexpected",
-    "nodeType": "BinaryExpression",
-    "ruleId": "no-bitwise",
+    "column": 7,
+    "endColumn": 9,
+    "endLine": 6,
+    "line": 6,
+    "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+    "messageId": "preferNullish",
+    "nodeType": "Punctuator",
+    "ruleId": "@typescript-eslint/prefer-nullish-coalescing",
     "severity": 2,
+    "suggestions": Array [
+      Object {
+        "desc": "Fix to nullish coalescing operator (\`??\`).",
+        "fix": Object {
+          "range": Array [
+            263,
+            265,
+          ],
+          "text": "??",
+        },
+        "messageId": "suggestNullish",
+      },
+    ],
   },
 ]
 `;

--- a/test/fixtures/@typescript-eslint/prefer-nullish-coalescing.fail.ts
+++ b/test/fixtures/@typescript-eslint/prefer-nullish-coalescing.fail.ts
@@ -1,8 +1,6 @@
-/**
- * cspell:ignore viestat
- * TODO (viestat) [2022-04-01]: Nothing makes this rule fail. Need to look
- * into it.
- * See: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
- */
-
-const somethingShouldFailNow = 0 << 1;
+/* eslint-disable functional/no-let */
+/* eslint-disable @typescript-eslint/init-declarations */
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
+let value: string | undefined;
+value || 'fallback';

--- a/test/fixtures/@typescript-eslint/prefer-nullish-coalescing.fail.ts
+++ b/test/fixtures/@typescript-eslint/prefer-nullish-coalescing.fail.ts
@@ -1,6 +1,6 @@
 /**
  * cspell:ignore viestat
- * TODO (viestat) [2022-02-01]: Nothing makes this rule fail. Need to look
+ * TODO (viestat) [2022-04-01]: Nothing makes this rule fail. Need to look
  * into it.
  * See: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
  */

--- a/test/fixtures/unicorn/prefer-add-event-listener.pass.ts
+++ b/test/fixtures/unicorn/prefer-add-event-listener.pass.ts
@@ -1,4 +1,2 @@
-/**
- * cspell:ignore viestat
- * TODO (viestat) [2022-04-01]: Find a good way to test this
- */
+const button = {} as HTMLButtonElement;
+button.addEventListener('click', (): void => {});

--- a/test/fixtures/unicorn/prefer-add-event-listener.pass.ts
+++ b/test/fixtures/unicorn/prefer-add-event-listener.pass.ts
@@ -1,4 +1,4 @@
 /**
  * cspell:ignore viestat
- * TODO (viestat) [2022-02-01]: Find a good way to test this
+ * TODO (viestat) [2022-04-01]: Find a good way to test this
  */

--- a/test/fixtures/unicorn/prefer-node-append.fail.ts
+++ b/test/fixtures/unicorn/prefer-node-append.fail.ts
@@ -1,3 +1,0 @@
-const appendFail = [];
-
-appendFail.appendChild(bar);

--- a/test/fixtures/unicorn/prefer-node-append.pass.ts
+++ b/test/fixtures/unicorn/prefer-node-append.pass.ts
@@ -1,4 +1,0 @@
-/**
- * cspell:ignore viestat
- * TODO (viestat) [2021-11-01]: Find a good way to test as this is for browser.
- */

--- a/test/fixtures/unicorn/prefer-node-remove.fail.ts
+++ b/test/fixtures/unicorn/prefer-node-remove.fail.ts
@@ -1,7 +1,0 @@
-/**
- * cspell:ignore viestat
- * TODO (viestat) [2021-11-01]: Find a good way to test as this is for browser.
- * The fixture bellow fails for a different reason on purpose.
- */
-
-const hereTofailThisFixture = 0 << 1;

--- a/test/fixtures/unicorn/prefer-node-remove.pass.ts
+++ b/test/fixtures/unicorn/prefer-node-remove.pass.ts
@@ -1,4 +1,0 @@
-/**
- * cspell:ignore viestat
- * TODO (viestat) [2021-11-01]: Find a good way to test as this is for browser.
- */

--- a/test/fixtures/unicorn/prefer-query-selector.fail.ts
+++ b/test/fixtures/unicorn/prefer-query-selector.fail.ts
@@ -1,7 +1,1 @@
-/**
- * cspell:ignore viestat
- * TODO (viestat) [2022-04-01]: Find a good way to test as this is for browser.
- * The fixture bellow fails for a different reason on purpose.
- */
-
-const hereTofailThisFixture2 = 0 << 1;
+document.getElementById("foo");

--- a/test/fixtures/unicorn/prefer-query-selector.fail.ts
+++ b/test/fixtures/unicorn/prefer-query-selector.fail.ts
@@ -1,1 +1,1 @@
-document.getElementById("foo");
+document.getElementById('foo');

--- a/test/fixtures/unicorn/prefer-query-selector.fail.ts
+++ b/test/fixtures/unicorn/prefer-query-selector.fail.ts
@@ -1,6 +1,6 @@
 /**
  * cspell:ignore viestat
- * TODO (viestat) [2022-02-01]: Find a good way to test as this is for browser.
+ * TODO (viestat) [2022-04-01]: Find a good way to test as this is for browser.
  * The fixture bellow fails for a different reason on purpose.
  */
 

--- a/test/fixtures/unicorn/prefer-query-selector.pass.ts
+++ b/test/fixtures/unicorn/prefer-query-selector.pass.ts
@@ -1,3 +1,2 @@
-/**
- * TODO: this is for browser, find good way to test.
- */
+document.querySelector('#foo');
+document.querySelectorAll('li a');


### PR DESCRIPTION
At first I wanted to bump the TODOs like we usually do to unblock dependabot updates, but realized that I was the one who bumped them the last time, and it's been quite a while since they were created.

Test cases are inspired by the ones in the original repos for eslint-plugin-unicorn and typescript-eslint. Since we don't do any additional configuration for these specific rules, I assume there's no reason to add more test cases as they are covered in "parent" repos, and we just want to check that they're enabled.

I also found a few TODOs which are outdated but not reported and do not block dependabot, because the tests are actually not used, as these rules were removed a while ago: https://github.com/ridedott/eslint-config/commit/2de6a7306369976d8465efbe42b76e6070f40623#diff-eafbe97ee7fea4656764bf94e779c0ddbe747c72e2664277652359c0b373f345, removed them.