### PR TITLE
feat: allow different casing for properties requiring quotes

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -167,6 +167,12 @@ module.exports = {
         format: null,
         selector: 'default',
       },
+      // Allow properties that require quotes (for example, containing dashes etc.)
+      {
+        selector: 'property',
+        modifiers: ['requiresQuotes'],
+        format: null,
+      },
     ],
     '@typescript-eslint/no-dynamic-delete': 'error',
     // Empty functions are often used as no operation.

--- a/test/fixtures/@typescript-eslint/naming-convention.pass.ts
+++ b/test/fixtures/@typescript-eslint/naming-convention.pass.ts
@@ -29,3 +29,7 @@ const { Aaa } = NCE;
 interface Entity {
   _version: number;
 }
+
+const objectWithKeysThatRequireQuotes = {
+  'some-key': true
+}

--- a/test/fixtures/@typescript-eslint/naming-convention.pass.ts
+++ b/test/fixtures/@typescript-eslint/naming-convention.pass.ts
@@ -31,5 +31,5 @@ interface Entity {
 }
 
 const objectWithKeysThatRequireQuotes = {
-  'some-key': true
-}
+  'some-key': true,
+};


### PR DESCRIPTION
[Recently](https://github.com/ridedott/eslint-config/pull/1461) we updated `@typescript-eslint/eslint-plugin`, and that update included a [release](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v5.14.0) where the behavior of `naming-convention` rule got [changed](https://github.com/typescript-eslint/typescript-eslint/pull/4582). Because of this, versions of `@ridedott/eslint-plugin` that came after are complaining about cases like this:
```
<span style=${styleMap({ 'background-color': 'red' })}>
```
because `background-color` is not written in camel case.

There's quite a lot of cases like this in frontend repos, usually it's specifying CSS class names in the code (which are usually dash-separated and not camel cased). It seems there's also quite a lot of similar errors in other repos (you can check the open PRs for updating `@ridedott/esling-config`), for example like this:
```
Error:   47:3  error  Object Literal Property name `already-exists` must match one of the following formats: camelCase       @typescript-eslint/naming-convention
```

I don't think we can really override this in our own ESLint configs, because then we would need to copy-paste other custom configurations for this rule that we have, so I was thinking maybe we could change it  in this config. To me it seems logical to not check properties that require quotes anyway, because it usually means they have some symbols like `-` or `@`, but please let me know if you think otherwise, or maybe there's something that I'm missing here.