### PR TITLE
feat: update Husky setup

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Go the the right directory and install dependencies:
 ```bash
 cd eslint-config
 npm install
+npx husky install
 ```
 
 That's it! You can now go to the next step.

--- a/package.json
+++ b/package.json
@@ -48,12 +48,6 @@
     "rules",
     "README.md"
   ],
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "lint-staged"
-    }
-  },
   "license": "UNLICENSED",
   "lint-staged": {
     "*.{js,json,md,yml,yaml}": [


### PR DESCRIPTION
Makes sure that the Husky setup is working with v8 again.

Note: You need to run `npx husky install` as part of the setup after `npm install/ci`