### PR TITLE
chore: all external dependencies from dangerfile

### DIFF
--- a/rules/import.js
+++ b/rules/import.js
@@ -15,6 +15,7 @@ module.exports = {
           'monitoring/**',
           'scripts/**',
           'test/**',
+          'dangerfile.ts'
         ],
         optionalDependencies: false,
         bundledDependencies: false,

--- a/rules/import.js
+++ b/rules/import.js
@@ -15,7 +15,7 @@ module.exports = {
           'monitoring/**',
           'scripts/**',
           'test/**',
-          'dangerfile.ts'
+          'dangerfile.ts',
         ],
         optionalDependencies: false,
         bundledDependencies: false,


### PR DESCRIPTION
As the Service Health team is experimenting with [danger](https://github.com/danger/danger) (which requires us to add a devDependency as well as a TS file at the root of the project), our eslint config complains about the external dependencies being used.

This PR allows external dependencies inside the `dangerfile.ts`