### PR TITLE
revert: chore(deps-dev): bump @types/node from 12.20.55 to 16.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@commitlint/config-conventional": "^17.3.0",
         "@types/eslint": "^8.4.2",
         "@types/jest": "^29.2.4",
-        "@types/node": "^16.0.0",
+        "@types/node": "^12.20.4",
         "babel-jest": "^29.3.1",
         "commitizen": "^4.2.6",
         "husky": "^8.0.2",
@@ -3323,9 +3323,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz",
-      "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==",
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -14080,9 +14080,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz",
-      "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==",
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@commitlint/config-conventional": "^17.3.0",
     "@types/eslint": "^8.4.2",
     "@types/jest": "^29.2.4",
-    "@types/node": "^16.0.0",
+    "@types/node": "^12.20.4",
     "babel-jest": "^29.3.1",
     "commitizen": "^4.2.6",
     "husky": "^8.0.2",


### PR DESCRIPTION
Reverts 40959a36c1066a64b1ac5399546f910c9c625239.