### PR TITLE
chore: allow newest node 16 typings

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -22,11 +22,11 @@ updates:
     ignore:
       - dependency-name: '@types/node'
         versions:
-          - '> 16'
+          - '>= 17'
         # babel-jest needs to be updated together with Jest
       - dependency-name: 'babel-jest'
         versions:
-          - '>29'
+          - '> 29'
     open-pull-requests-limit: 99
     package-ecosystem: npm
     reviewers:


### PR DESCRIPTION
The current ignore rule actually will only allow the @types/node 16.0.0 release and not one of the newer 16.x.x releases, which this should fix.