### PR TITLE
chore: extend from recommended plugin configurations

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 module.exports = {
   extends: [
-    'eslint:all',
-    'plugin:@typescript-eslint/all',
+    'eslint:recommended',
+    'plugin:@typescript-eslint/strict-type-checked',
+    'plugin:@typescript-eslint/stylistic-type-checked',
     'plugin:@ridedott/all',
     'plugin:import/typescript',
-    'plugin:jest/all',
+    'plugin:jest/recommended',
+    'plugin:jest/style',
     './rules/array-func.js',
     './rules/eslint-comments.js',
     './rules/eslint.js',


### PR DESCRIPTION
Both `@typescript-eslint/eslint-plugin` and `eslint-plugin-jest` have recommended configurations that tend to change on major releases and not at any time like their "all" configurations.

This PR moves to the recommended configurations to reduce the likelyhood of linting errors coming up (and thus developer time being required) as part of even minor version bumps of the libraries.