### PR TITLE
chore: removed no longer used vscode setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,5 @@
     "resolvePluginsRelativeTo": "./node_modules/@ridedott/eslint-config"
   },
   "eslint.run": "onType",
-  "jest.autoEnable": false,
   "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
Jest was removed in https://github.com/ridedott/eslint-config/pull/2488, so this is no longer needed.