### PR TITLE
feat: use recommended unicorn config

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ export default [
   ...typescriptEslintPlugin.configs.all,
   eslintPluginImport.configs.typescript,
   jestPlugin.configs['flat/all'],
+  unicornPlugin.configs['flat/recommended'],
 
   arrayFuncConfig,
   eslintCommentsConfig,
@@ -46,7 +47,6 @@ export default [
       functional: eslintPluginFunctional,
       import: eslintPluginImport,
       'simple-import-sort': simpleImportSortPlugin,
-      unicorn: unicornPlugin,
     },
 
     languageOptions: {

--- a/rules/unicorn.js
+++ b/rules/unicorn.js
@@ -1,102 +1,49 @@
 export default {
   rules: {
     'unicorn/better-regex': 'error',
-    'unicorn/catch-error-name': 'error',
     'unicorn/consistent-destructuring': 'error',
-    'unicorn/consistent-function-scoping': 'error',
     'unicorn/custom-error-definition': 'error',
     // Code should be formatted using Prettier.
     'unicorn/empty-brace-spaces': 'off',
-    'unicorn/error-message': 'error',
-    'unicorn/escape-case': 'error',
     'unicorn/expiring-todo-comments': [
       'error',
       { allowWarningComments: false, ignoreDatesOnPullRequests: false },
     ],
-    'unicorn/explicit-length-check': ['error', { 'non-zero': 'greater-than' }],
     'unicorn/filename-case': ['error', { case: 'camelCase' }],
     // No good use cases yet.
     'unicorn/import-style': 'off',
-    'unicorn/new-for-builtins': 'error',
     // Covered by eslint-comments/no-unlimited-disable.
     'unicorn/no-abusive-eslint-disable': 'off',
     // Unnecessary with TypeScript.
     'unicorn/no-array-callback-reference': 'off',
-    'unicorn/no-array-for-each': 'error',
     // Covered by functional/no-this-expressions.
     'unicorn/no-array-method-this-argument': 'off',
-    'unicorn/no-array-push-push': 'error',
     'unicorn/no-array-reduce': 'off',
-    'unicorn/no-console-spaces': 'error',
-    'unicorn/no-for-loop': 'error',
-    'unicorn/no-hex-escape': 'error',
-    'unicorn/no-instanceof-builtins': 'error',
-    'unicorn/no-keyword-prefix': 'off',
-    'unicorn/no-lonely-if': 'error',
     // Ternary operators help write immutable code.
     'unicorn/no-nested-ternary': 'off',
-    'unicorn/no-new-array': 'error',
     // This is covered by @typescript-eslint/no-deprecated
     'unicorn/no-new-buffer': 'off',
     'unicorn/no-null': 'off',
     // Unnecessary with TypeScript.
     'unicorn/no-object-as-default-parameter': 'off',
-    'unicorn/no-process-exit': 'off',
-    // Do not use classes in the first place.
-    'unicorn/no-static-only-class': 'off',
     // Covered by consistent-this.
     'unicorn/no-this-assignment': 'off',
+    // Covered by @typescript-eslint/return-await
+    'unicorn/no-unnecessary-await': 'off',
     'unicorn/no-unreadable-array-destructuring': 'off',
-    'unicorn/no-unused-properties': 'off',
-    'unicorn/no-useless-length-check': 'error',
-    'unicorn/no-useless-spread': 'error',
     'unicorn/no-useless-undefined': 'off',
-    'unicorn/no-zero-fractions': 'error',
     // Code should be formatted using Prettier.
     'unicorn/number-literal-case': 'off',
-    'unicorn/numeric-separators-style': 'error',
-    'unicorn/prefer-add-event-listener': 'error',
-    'unicorn/prefer-array-find': 'error',
-    'unicorn/prefer-array-flat-map': 'error',
-    'unicorn/prefer-array-index-of': 'error',
-    'unicorn/prefer-array-some': 'error',
-    // Not available in Node.js nor TypeScript yet.
-    'unicorn/prefer-at': 'off',
-    'unicorn/prefer-date-now': 'error',
-    'unicorn/prefer-default-parameters': 'error',
-    // Manual DOM manipulation is discouraged.
-    'unicorn/prefer-dom-node-append': 'off',
-    'unicorn/prefer-dom-node-dataset': 'off',
-    // Manual DOM manipulation is discouraged.
-    'unicorn/prefer-dom-node-remove': 'off',
-    // Manual DOM manipulation is discouraged.
-    'unicorn/prefer-dom-node-text-content': 'off',
-    'unicorn/prefer-includes': 'error',
     // This is covered by @typescript-eslint/no-deprecated
     'unicorn/prefer-keyboard-event-key': 'off',
-    'unicorn/prefer-math-trunc': 'error',
-    'unicorn/prefer-negative-index': 'error',
-    'unicorn/prefer-number-properties': 'error',
-    'unicorn/prefer-object-from-entries': 'error',
-    // Not supported yet.
-    'unicorn/prefer-object-has-own': 'off',
     // TypeScript `noUnusedLocals` covers this.
     'unicorn/prefer-optional-catch-binding': 'off',
-    'unicorn/prefer-prototype-methods': 'error',
-    'unicorn/prefer-query-selector': 'error',
-    'unicorn/prefer-reflect-apply': 'error',
     // Does not work with strict type checking.
     'unicorn/prefer-regexp-test': 'off',
-    'unicorn/prefer-set-has': 'error',
     // Prefer `Array.from` for performance benefits.
     'unicorn/prefer-spread': 'off',
-    'unicorn/prefer-string-replace-all': 'error',
-    'unicorn/prefer-string-slice': 'error',
-    'unicorn/prefer-string-starts-ends-with': 'error',
     // This is covered by @typescript-eslint/no-deprecated
     'unicorn/prefer-string-trim-start-end': 'off',
-    'unicorn/prefer-ternary': 'error',
-    'unicorn/prefer-top-level-await': 'error',
     // Type checks are performed by TypeScript compiler.
     'unicorn/prefer-type-error': 'off',
     'unicorn/prevent-abbreviations': [
@@ -113,10 +60,6 @@ export default {
         },
       },
     ],
-    'unicorn/require-array-join-separator': 'error',
-    'unicorn/require-number-to-fixed-digits-argument': 'error',
-    // No good use cases yet.
-    'unicorn/string-content': 'off',
-    'unicorn/throw-new-error': 'error',
+    'unicorn/switch-case-braces': ['error', 'avoid'],
   },
 };

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -3744,7 +3744,7 @@ exports[`unicorn rules > unicorn/prefer-object-from-entries > fails on an invali
   Record<string, number>
 >(
   (
-
+    
     [key, value]: [string, number],
   ): Record<string, number> => [key, value],
 ))",

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -639,7 +639,7 @@ exports[`import rules > import/no-cycle > fails on an invalid fixture 1`] = `
     "endLine": 1,
     "line": 1,
     "message": "Dependency cycle detected.",
-    "nodeType": "ImportDeclaration",
+    "nodeType": "ExportNamedDeclaration",
     "ruleId": "import/no-cycle",
     "severity": 2,
   },
@@ -831,15 +831,15 @@ exports[`simpleImportSort rules > simple-import-sort/imports > fails on an inval
 [
   {
     "column": 1,
-    "endColumn": 34,
+    "endColumn": 39,
     "endLine": 2,
     "fix": {
       "range": [
         0,
-        63,
+        73,
       ],
-      "text": "import * as assert from 'assert';
-import * as path from 'path';",
+      "text": "import * as assert from 'node:assert';
+import * as path from 'node:path';",
     },
     "line": 1,
     "message": "Run autofix to sort these imports!",
@@ -1866,8 +1866,26 @@ exports[`typescriptEslint rules > @typescript-eslint/return-await > fails on an 
     ],
   },
   {
+    "column": 12,
+    "endColumn": 27,
+    "endLine": 10,
+    "fix": {
+      "range": [
+        336,
+        366,
+      ],
+      "text": "return 'try';",
+    },
+    "line": 10,
+    "message": "Prefer \`return value\` over \`return Promise.resolve(value)\`.",
+    "messageId": "resolve",
+    "nodeType": "MemberExpression",
+    "ruleId": "unicorn/no-useless-promise-resolve-reject",
+    "severity": 2,
+  },
+  {
     "column": 10,
-    "endColumn": 38,
+    "endColumn": 21,
     "endLine": 17,
     "fix": {
       "range": [
@@ -1877,24 +1895,6 @@ exports[`typescriptEslint rules > @typescript-eslint/return-await > fails on an 
       "text": "",
     },
     "line": 17,
-    "message": "Returning an awaited promise is not allowed in this context.",
-    "messageId": "disallowedPromiseAwait",
-    "nodeType": "AwaitExpression",
-    "ruleId": "@typescript-eslint/return-await",
-    "severity": 2,
-  },
-  {
-    "column": 10,
-    "endColumn": 23,
-    "endLine": 21,
-    "fix": {
-      "range": [
-        550,
-        556,
-      ],
-      "text": "",
-    },
-    "line": 21,
     "message": "Returning an awaited value that is not a promise is not allowed.",
     "messageId": "nonPromiseAwait",
     "nodeType": "AwaitExpression",
@@ -3744,7 +3744,7 @@ exports[`unicorn rules > unicorn/prefer-object-from-entries > fails on an invali
   Record<string, number>
 >(
   (
-    
+
     [key, value]: [string, number],
   ): Record<string, number> => [key, value],
 ))",

--- a/test/fixtures/@typescript-eslint/promise-function-async.pass.ts
+++ b/test/fixtures/@typescript-eslint/promise-function-async.pass.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable func-style */
+/* eslint-disable unicorn/no-useless-promise-resolve-reject */
 
 const arrowFunctionReturnsPromise2 = async () => Promise.resolve('value');
 

--- a/test/fixtures/@typescript-eslint/return-await.fail.ts
+++ b/test/fixtures/@typescript-eslint/return-await.fail.ts
@@ -14,9 +14,5 @@ async function invalidInTryCatch1() {
 }
 
 async function invalidInTryCatch2() {
-  return await Promise.resolve('try');
-}
-
-async function invalidInTryCatch3() {
-  return await 'value';
+  return await 'try';
 }

--- a/test/fixtures/@typescript-eslint/return-await.pass.ts
+++ b/test/fixtures/@typescript-eslint/return-await.pass.ts
@@ -13,9 +13,5 @@ async function validInTryCatch1() {
 }
 
 async function validInTryCatch2() {
-  return Promise.resolve('try');
-}
-
-async function validInTryCatch3() {
-  return 'value';
+  return 'try';
 }

--- a/test/fixtures/eslint-comments/no-use.fail.ts
+++ b/test/fixtures/eslint-comments/no-use.fail.ts
@@ -7,3 +7,4 @@
 /* exported foo */
 /* global $ */
 /* globals a, b, c */
+const preventUnicornNoEmptyFileError = true;

--- a/test/fixtures/eslint/capitalized-comments.fail.ts
+++ b/test/fixtures/eslint/capitalized-comments.fail.ts
@@ -3,3 +3,4 @@
 // cspell ignore:this
 
 // c8 ignore next 4
+const preventUnicornNoEmptyFileError = true;

--- a/test/fixtures/eslint/capitalized-comments.pass.ts
+++ b/test/fixtures/eslint/capitalized-comments.pass.ts
@@ -17,3 +17,4 @@
 /* cspell ignore:this */
 
 /* c8 ignore next 4 */
+const preventUnicornNoEmptyFileError = true;

--- a/test/fixtures/import/no-cycle.fail.ts
+++ b/test/fixtures/import/no-cycle.fail.ts
@@ -1,3 +1,1 @@
-import { value } from './no-cycle/a';
-
-export { value };
+export { value } from './no-cycle/a';

--- a/test/fixtures/import/no-cycle/a.ts
+++ b/test/fixtures/import/no-cycle/a.ts
@@ -1,3 +1,1 @@
-import { value } from '../no-cycle.fail';
-
-export { value };
+export { value } from '../no-cycle.fail';

--- a/test/fixtures/simple-import-sort/imports.fail.ts
+++ b/test/fixtures/simple-import-sort/imports.fail.ts
@@ -1,2 +1,2 @@
-import * as path from 'path';
-import * as assert from 'assert';
+import * as path from 'node:path';
+import * as assert from 'node:assert';

--- a/test/fixtures/simple-import-sort/imports.pass.ts
+++ b/test/fixtures/simple-import-sort/imports.pass.ts
@@ -1,2 +1,2 @@
-import * as assert from 'assert';
-import * as path from 'path';
+import * as assert from 'node:assert';
+import * as path from 'node:path';

--- a/test/fixtures/unicorn/expiring-todo-comments.fail.ts
+++ b/test/fixtures/unicorn/expiring-todo-comments.fail.ts
@@ -15,3 +15,4 @@
  * TODO [2002-12-25]: Another
  * TODO [2002-12-25]: Way
  */
+const preventUnicornNoEmptyFileError = true;

--- a/test/fixtures/unicorn/expiring-todo-comments.pass.ts
+++ b/test/fixtures/unicorn/expiring-todo-comments.pass.ts
@@ -12,3 +12,4 @@
  * TODO [2200-12-25]: Another
  * TODO [2200-12-25]: Way
  */
+const preventUnicornNoEmptyFileError = true;

--- a/test/fixtures/unicorn/filename-case.pass.ts
+++ b/test/fixtures/unicorn/filename-case.pass.ts
@@ -3,3 +3,4 @@
  * unicorn/filename-case rule is disabled for test files as they match
  * rule names.
  */
+const preventUnicornNoEmptyFileError = true;

--- a/test/fixtures/unicorn/prefer-ternary.pass.ts
+++ b/test/fixtures/unicorn/prefer-ternary.pass.ts
@@ -3,5 +3,5 @@
 /* eslint-disable no-constant-condition */
 
 const preferTernaryPass = function* (): Iterable<string> {
-  yield 'a' ? 'a' : 'b';
+  yield 'test' ? 'a' : 'b';
 };

--- a/test/fixtures/unicorn/prefer-top-level-await.pass.ts
+++ b/test/fixtures/unicorn/prefer-top-level-await.pass.ts
@@ -1,1 +1,1 @@
-// Can't write tests before the repository is migrated to ESM.
+await run();


### PR DESCRIPTION
To get the most out of the ESLint plugins we include, it's better if we extend recommended rules so that we get useful updates whenever they're extended. I reviewed our rule overrides to check which have the same configuration in the recommended config and removed these, left a few that are configured differently.