### PR TITLE
feat: disable unicorn/prefer-event-target

### DIFF
--- a/rules/unicorn.js
+++ b/rules/unicorn.js
@@ -1,7 +1,6 @@
 export default {
   rules: {
     'unicorn/better-regex': 'error',
-    'unicorn/consistent-assert': 'off',
     'unicorn/consistent-destructuring': 'error',
     'unicorn/custom-error-definition': 'error',
     // Code should be formatted using Prettier.

--- a/rules/unicorn.js
+++ b/rules/unicorn.js
@@ -1,6 +1,7 @@
 export default {
   rules: {
     'unicorn/better-regex': 'error',
+    'unicorn/consistent-assert': 'off',
     'unicorn/consistent-destructuring': 'error',
     'unicorn/custom-error-definition': 'error',
     // Code should be formatted using Prettier.
@@ -36,6 +37,7 @@ export default {
     'unicorn/no-useless-undefined': 'off',
     // Code should be formatted using Prettier.
     'unicorn/number-literal-case': 'off',
+    'unicorn/prefer-event-target': 'off',
     // This is covered by @typescript-eslint/no-deprecated
     'unicorn/prefer-keyboard-event-key': 'off',
     // TypeScript `noUnusedLocals` covers this.


### PR DESCRIPTION
For both of these rules we have way more usages for the "not alllowed" option. The rules seem to be more on the stylistic preference side, so disabling them both. 