### PR TITLE
feat: correctly set stylistic rules

### DIFF
--- a/configs/stylistic.js
+++ b/configs/stylistic.js
@@ -6,7 +6,7 @@ export default [
       '@stylistic': stylistic,
     },
     rules: {
-      'max-len': [
+      '@stylistic/max-len': [
         'error',
         {
           code: 1024,
@@ -15,8 +15,8 @@ export default [
           ignoreUrls: true,
         },
       ],
-      'multiline-comment-style': 'error',
-      'padding-line-between-statements': [
+      '@stylistic/multiline-comment-style': 'error',
+      '@stylistic/padding-line-between-statements': [
         'error',
         { blankLine: 'always', prev: '*', next: 'block-like' },
         { blankLine: 'always', prev: '*', next: 'block' },

--- a/makeConfig.js
+++ b/makeConfig.js
@@ -19,10 +19,11 @@ const configs = [
   functionalConfig,
   importConfig,
   simpleImportSortConfig,
-  stylisticConfig,
   typescriptConfig,
   unicornConfig,
 ];
+
+const alsoConfigs = [stylisticConfig]
 
 const makeOptionsConfig = () => ({
   languageOptions: {
@@ -45,6 +46,8 @@ export const makeConfig = (additionalConfigs = []) => [
   makeOptionsConfig(),
   // eslint-config-prettier should have the opportunity to override other configs, so is last
   eslintConfigPrettier,
+  // eslint-config-prettier overrides some @stylistic rules. Set them back.
+  ...alsoConfigs.flat(),
 ];
 
 export const makeConfigESM = (additionalConfigs = []) => [
@@ -62,4 +65,6 @@ export const makeConfigESM = (additionalConfigs = []) => [
   },
   // eslint-config-prettier should have the opportunity to override other configs, so is last
   eslintConfigPrettier,
+  // eslint-config-prettier overrides some @stylistic rules. Set them back.
+  ...alsoConfigs.flat(),
 ];

--- a/makeConfig.js
+++ b/makeConfig.js
@@ -23,8 +23,6 @@ const configs = [
   unicornConfig,
 ];
 
-const alsoConfigs = [stylisticConfig]
-
 const makeOptionsConfig = () => ({
   languageOptions: {
     globals: { ...globals.node },
@@ -47,7 +45,8 @@ export const makeConfig = (additionalConfigs = []) => [
   // eslint-config-prettier should have the opportunity to override other configs, so is last
   eslintConfigPrettier,
   // eslint-config-prettier overrides some @stylistic rules. Set them back.
-  ...alsoConfigs.flat(),
+  ...stylisticConfig,
+  // ...alsoConfigs.flat(),
 ];
 
 export const makeConfigESM = (additionalConfigs = []) => [
@@ -66,5 +65,5 @@ export const makeConfigESM = (additionalConfigs = []) => [
   // eslint-config-prettier should have the opportunity to override other configs, so is last
   eslintConfigPrettier,
   // eslint-config-prettier overrides some @stylistic rules. Set them back.
-  ...alsoConfigs.flat(),
+  ...stylisticConfig,
 ];

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -666,8 +666,8 @@ exports[`import rules > import/no-extraneous-dependencies > fails on an invalid 
   {
     "column": 1,
     "endColumn": 39,
-    "endLine": 3,
-    "line": 3,
+    "endLine": 4,
+    "line": 4,
     "message": "'npm-run-all' should be listed in the project's dependencies, not devDependencies.",
     "nodeType": "ExportAllDeclaration",
     "ruleId": "import/no-extraneous-dependencies",
@@ -856,8 +856,8 @@ exports[`stylistic rules > @stylistic/max-len > fails on an invalid fixture 1`] 
   {
     "column": 1,
     "endColumn": 157,
-    "endLine": 4,
-    "line": 4,
+    "endLine": 3,
+    "line": 3,
     "message": "This line has a comment length of 156. Maximum allowed is 80.",
     "messageId": "maxComment",
     "nodeType": "Program",
@@ -1558,8 +1558,8 @@ exports[`typescriptEslint rules > @typescript-eslint/no-magic-numbers > fails on
   {
     "column": 28,
     "endColumn": 29,
-    "endLine": 3,
-    "line": 3,
+    "endLine": 4,
+    "line": 4,
     "message": "No magic number: 7.",
     "messageId": "noMagic",
     "nodeType": "Literal",
@@ -1569,8 +1569,8 @@ exports[`typescriptEslint rules > @typescript-eslint/no-magic-numbers > fails on
   {
     "column": 32,
     "endColumn": 33,
-    "endLine": 3,
-    "line": 3,
+    "endLine": 4,
+    "line": 4,
     "message": "No magic number: 5.",
     "messageId": "noMagic",
     "nodeType": "Literal",

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -4101,28 +4101,13 @@ exports[`unicorn rules > unicorn/require-number-to-fixed-digits-argument > fails
 exports[`unicorn rules > unicorn/throw-new-error > fails on an invalid fixture 1`] = `
 [
   {
-    "column": 1,
-    "fix": {
-      "range": [
-        29,
-        81,
-      ],
-      "text": " ",
-    },
-    "line": 2,
-    "message": "Unused eslint-disable directive (no problems were reported from 'padding-line-between-statements').",
-    "nodeType": null,
-    "ruleId": null,
-    "severity": 2,
-  },
-  {
     "column": 7,
     "endColumn": 23,
     "endLine": 5,
     "fix": {
       "range": [
-        135,
-        135,
+        146,
+        146,
       ],
       "text": "new ",
     },
@@ -4134,32 +4119,13 @@ exports[`unicorn rules > unicorn/throw-new-error > fails on an invalid fixture 1
     "severity": 2,
   },
   {
-    "column": 1,
-    "endColumn": 28,
-    "endLine": 6,
-    "fix": {
-      "range": [
-        152,
-        152,
-      ],
-      "text": "
-",
-    },
-    "line": 6,
-    "message": "Expected blank line before this statement.",
-    "messageId": "expectedBlankLine",
-    "nodeType": "ThrowStatement",
-    "ruleId": "@stylistic/padding-line-between-statements",
-    "severity": 2,
-  },
-  {
     "column": 7,
     "endColumn": 27,
     "endLine": 6,
     "fix": {
       "range": [
-        159,
-        159,
+        170,
+        170,
       ],
       "text": "new ",
     },

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -851,7 +851,23 @@ import * as path from 'node:path';",
 ]
 `;
 
-exports[`stylistic rules > multiline-comment-style > fails on an invalid fixture 1`] = `
+exports[`stylistic rules > @stylistic/max-len > fails on an invalid fixture 1`] = `
+[
+  {
+    "column": 1,
+    "endColumn": 157,
+    "endLine": 4,
+    "line": 4,
+    "message": "This line has a comment length of 156. Maximum allowed is 80.",
+    "messageId": "maxComment",
+    "nodeType": "Program",
+    "ruleId": "@stylistic/max-len",
+    "severity": 2,
+  },
+]
+`;
+
+exports[`stylistic rules > @stylistic/multiline-comment-style > fails on an invalid fixture 1`] = `
 [
   {
     "column": 1,
@@ -869,7 +885,7 @@ exports[`stylistic rules > multiline-comment-style > fails on an invalid fixture
     "message": "Expected a linebreak after '/*'.",
     "messageId": "startNewline",
     "nodeType": null,
-    "ruleId": "multiline-comment-style",
+    "ruleId": "@stylistic/multiline-comment-style",
     "severity": 2,
   },
   {
@@ -887,7 +903,7 @@ exports[`stylistic rules > multiline-comment-style > fails on an invalid fixture
     "message": "Expected a '*' at the start of this line.",
     "messageId": "missingStar",
     "nodeType": null,
-    "ruleId": "multiline-comment-style",
+    "ruleId": "@stylistic/multiline-comment-style",
     "severity": 2,
   },
   {
@@ -906,13 +922,13 @@ exports[`stylistic rules > multiline-comment-style > fails on an invalid fixture
     "message": "Expected a linebreak before '*/'.",
     "messageId": "endNewline",
     "nodeType": null,
-    "ruleId": "multiline-comment-style",
+    "ruleId": "@stylistic/multiline-comment-style",
     "severity": 2,
   },
 ]
 `;
 
-exports[`stylistic rules > padding-line-between-statements > fails on an invalid fixture 1`] = `
+exports[`stylistic rules > @stylistic/padding-line-between-statements > fails on an invalid fixture 1`] = `
 [
   {
     "column": 3,
@@ -930,7 +946,7 @@ exports[`stylistic rules > padding-line-between-statements > fails on an invalid
     "message": "Expected blank line before this statement.",
     "messageId": "expectedBlankLine",
     "nodeType": "IfStatement",
-    "ruleId": "padding-line-between-statements",
+    "ruleId": "@stylistic/padding-line-between-statements",
     "severity": 2,
   },
   {
@@ -949,7 +965,7 @@ exports[`stylistic rules > padding-line-between-statements > fails on an invalid
     "message": "Expected blank line before this statement.",
     "messageId": "expectedBlankLine",
     "nodeType": "ExpressionStatement",
-    "ruleId": "padding-line-between-statements",
+    "ruleId": "@stylistic/padding-line-between-statements",
     "severity": 2,
   },
   {
@@ -968,7 +984,7 @@ exports[`stylistic rules > padding-line-between-statements > fails on an invalid
     "message": "Expected blank line before this statement.",
     "messageId": "expectedBlankLine",
     "nodeType": "ReturnStatement",
-    "ruleId": "padding-line-between-statements",
+    "ruleId": "@stylistic/padding-line-between-statements",
     "severity": 2,
   },
 ]
@@ -2323,8 +2339,8 @@ exports[`unicorn rules > unicorn/expiring-todo-comments > fails on an invalid fi
   {
     "column": 1,
     "endColumn": 47,
-    "endLine": 1,
-    "line": 1,
+    "endLine": 3,
+    "line": 3,
     "message": "There is a TODO that is past due date: 2000-01-01. I'll fix this next week.",
     "messageId": "unicorn/expiredTodo",
     "nodeType": null,
@@ -2334,29 +2350,8 @@ exports[`unicorn rules > unicorn/expiring-todo-comments > fails on an invalid fi
   {
     "column": 1,
     "endColumn": 61,
-    "endLine": 2,
-    "fix": {
-      "range": [
-        0,
-        107,
-      ],
-      "text": "/*
- * TODO [2000-01-01]: I'll fix this next week.
- * TODO [2000-01-01, 2001-01-01]: Multiple dates won't work.
- */",
-    },
-    "line": 1,
-    "message": "Expected a block comment instead of consecutive line comments.",
-    "messageId": "expectedBlock",
-    "nodeType": null,
-    "ruleId": "multiline-comment-style",
-    "severity": 2,
-  },
-  {
-    "column": 1,
-    "endColumn": 61,
-    "endLine": 2,
-    "line": 2,
+    "endLine": 4,
+    "line": 4,
     "message": "Avoid using multiple expiration dates in TODO: 2000-01-01, 2001-01-01. Multiple dates won't work.",
     "messageId": "unicorn/avoidMultipleDates",
     "nodeType": null,
@@ -2366,8 +2361,8 @@ exports[`unicorn rules > unicorn/expiring-todo-comments > fails on an invalid fi
   {
     "column": 1,
     "endColumn": 51,
-    "endLine": 4,
-    "line": 4,
+    "endLine": 6,
+    "line": 6,
     "message": "There is a TODO that is past due package version: >1. If your package.json version is > 1.",
     "messageId": "unicorn/reachedPackageVersion",
     "nodeType": null,
@@ -2376,31 +2371,9 @@ exports[`unicorn rules > unicorn/expiring-todo-comments > fails on an invalid fi
   },
   {
     "column": 1,
-    "endColumn": 56,
-    "endLine": 6,
-    "fix": {
-      "range": [
-        109,
-        268,
-      ],
-      "text": "/*
- * TODO [>1]: If your package.json version is > 1.
- * TODO [>=1]: If your package.json version is >= 1.
- * TODO [>1, >2]: Multiple package versions won't work.
- */",
-    },
-    "line": 4,
-    "message": "Expected a block comment instead of consecutive line comments.",
-    "messageId": "expectedBlock",
-    "nodeType": null,
-    "ruleId": "multiline-comment-style",
-    "severity": 2,
-  },
-  {
-    "column": 1,
     "endColumn": 53,
-    "endLine": 5,
-    "line": 5,
+    "endLine": 7,
+    "line": 7,
     "message": "There is a TODO that is past due package version: >=1. If your package.json version is >= 1.",
     "messageId": "unicorn/reachedPackageVersion",
     "nodeType": null,
@@ -2410,8 +2383,8 @@ exports[`unicorn rules > unicorn/expiring-todo-comments > fails on an invalid fi
   {
     "column": 1,
     "endColumn": 56,
-    "endLine": 6,
-    "line": 6,
+    "endLine": 8,
+    "line": 8,
     "message": "Avoid using multiple package versions in TODO: >1, >2. Multiple package versions won't work.",
     "messageId": "unicorn/avoidMultiplePackageVersions",
     "nodeType": null,
@@ -2421,29 +2394,8 @@ exports[`unicorn rules > unicorn/expiring-todo-comments > fails on an invalid fi
   {
     "column": 1,
     "endColumn": 77,
-    "endLine": 9,
-    "fix": {
-      "range": [
-        270,
-        415,
-      ],
-      "text": "/*
- * TODO [+already-have-pkg]: Since we already have it, this reports.
- * TODO [-we-dont-have-this-package]: Since we don't have, trigger a report.
- */",
-    },
-    "line": 8,
-    "message": "Expected a block comment instead of consecutive line comments.",
-    "messageId": "expectedBlock",
-    "nodeType": null,
-    "ruleId": "multiline-comment-style",
-    "severity": 2,
-  },
-  {
-    "column": 1,
-    "endColumn": 77,
-    "endLine": 9,
-    "line": 9,
+    "endLine": 11,
+    "line": 11,
     "message": "There is a TODO that is deprecated since you uninstalled: we-dont-have-this-package. Since we don't have, trigger a report.",
     "messageId": "unicorn/dontHavePackage",
     "nodeType": null,
@@ -2453,8 +2405,8 @@ exports[`unicorn rules > unicorn/expiring-todo-comments > fails on an invalid fi
   {
     "column": 1,
     "endColumn": 23,
-    "endLine": 11,
-    "line": 11,
+    "endLine": 13,
+    "line": 13,
     "message": "Unexpected 'todo' comment without any conditions: 'TODO: Add unicorns.'.",
     "messageId": "unexpectedComment",
     "nodeType": "Line",
@@ -2464,8 +2416,8 @@ exports[`unicorn rules > unicorn/expiring-todo-comments > fails on an invalid fi
   {
     "column": 1,
     "endColumn": 4,
-    "endLine": 17,
-    "line": 13,
+    "endLine": 19,
+    "line": 15,
     "message": "There is a TODO that is past due date: 2002-12-25. Yet",
     "messageId": "unicorn/expiredTodo",
     "nodeType": null,
@@ -2475,8 +2427,8 @@ exports[`unicorn rules > unicorn/expiring-todo-comments > fails on an invalid fi
   {
     "column": 1,
     "endColumn": 4,
-    "endLine": 17,
-    "line": 13,
+    "endLine": 19,
+    "line": 15,
     "message": "There is a TODO that is past due date: 2002-12-25. Another",
     "messageId": "unicorn/expiredTodo",
     "nodeType": null,
@@ -2486,8 +2438,8 @@ exports[`unicorn rules > unicorn/expiring-todo-comments > fails on an invalid fi
   {
     "column": 1,
     "endColumn": 4,
-    "endLine": 17,
-    "line": 13,
+    "endLine": 19,
+    "line": 15,
     "message": "There is a TODO that is past due date: 2002-12-25. Way",
     "messageId": "unicorn/expiredTodo",
     "nodeType": null,
@@ -4149,6 +4101,21 @@ exports[`unicorn rules > unicorn/require-number-to-fixed-digits-argument > fails
 exports[`unicorn rules > unicorn/throw-new-error > fails on an invalid fixture 1`] = `
 [
   {
+    "column": 1,
+    "fix": {
+      "range": [
+        29,
+        81,
+      ],
+      "text": " ",
+    },
+    "line": 2,
+    "message": "Unused eslint-disable directive (no problems were reported from 'padding-line-between-statements').",
+    "nodeType": null,
+    "ruleId": null,
+    "severity": 2,
+  },
+  {
     "column": 7,
     "endColumn": 23,
     "endLine": 5,
@@ -4164,6 +4131,25 @@ exports[`unicorn rules > unicorn/throw-new-error > fails on an invalid fixture 1
     "messageId": "throw-new-error",
     "nodeType": "CallExpression",
     "ruleId": "unicorn/throw-new-error",
+    "severity": 2,
+  },
+  {
+    "column": 1,
+    "endColumn": 28,
+    "endLine": 6,
+    "fix": {
+      "range": [
+        152,
+        152,
+      ],
+      "text": "
+",
+    },
+    "line": 6,
+    "message": "Expected blank line before this statement.",
+    "messageId": "expectedBlankLine",
+    "nodeType": "ThrowStatement",
+    "ruleId": "@stylistic/padding-line-between-statements",
     "severity": 2,
   },
   {

--- a/test/fixtures/@stylistic/max-len.fail.ts
+++ b/test/fixtures/@stylistic/max-len.fail.ts
@@ -1,0 +1,4 @@
+/* eslint-disable unicorn/prevent-abbreviations */
+
+// This is a very long comment that does not fit within the assigned character limit. So just defining something extra here to create some extra characters.
+export const foo = (): void => {};

--- a/test/fixtures/@stylistic/max-len.pass.ts
+++ b/test/fixtures/@stylistic/max-len.pass.ts
@@ -1,0 +1,4 @@
+/* eslint-disable unicorn/prevent-abbreviations */
+
+// This is a comment that first within the character limit.
+export const foo = (): void => {};

--- a/test/fixtures/@typescript-eslint/no-magic-numbers.fail.ts
+++ b/test/fixtures/@typescript-eslint/no-magic-numbers.fail.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @stylistic/max-len */
 /* eslint eslint-comments/no-use: off, @typescript-eslint/no-magic-numbers: "error" */
 
 const noMagicNumbersFail = 7 + 5;

--- a/test/fixtures/@typescript-eslint/no-magic-numbers.pass.ts
+++ b/test/fixtures/@typescript-eslint/no-magic-numbers.pass.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @stylistic/max-len */
 /* eslint eslint-comments/no-use: off, @typescript-eslint/no-magic-numbers: "error" */
 
 const NUMBER_FIVE = 5;

--- a/test/fixtures/import/no-extraneous-dependencies.fail.ts
+++ b/test/fixtures/import/no-extraneous-dependencies.fail.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @stylistic/max-len */
 /* eslint-disable eslint-comments/no-use */
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": false, "optionalDependencies": false, "bundledDependencies": false }] */
 export * as plugin from 'npm-run-all';

--- a/test/fixtures/import/no-extraneous-dependencies.pass.ts
+++ b/test/fixtures/import/no-extraneous-dependencies.pass.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @stylistic/max-len */
 /* eslint-disable eslint-comments/no-use */
 /* eslint-disable @typescript-eslint/consistent-type-exports */
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": false, "optionalDependencies": false, "bundledDependencies": false }] */

--- a/test/fixtures/unicorn/expiring-todo-comments.fail.ts
+++ b/test/fixtures/unicorn/expiring-todo-comments.fail.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @stylistic/multiline-comment-style */
+
 // TODO [2000-01-01]: I'll fix this next week.
 // TODO [2000-01-01, 2001-01-01]: Multiple dates won't work.
 

--- a/test/fixtures/unicorn/expiring-todo-comments.pass.ts
+++ b/test/fixtures/unicorn/expiring-todo-comments.pass.ts
@@ -1,4 +1,5 @@
-/* eslint-disable multiline-comment-style */
+/* eslint-disable @stylistic/multiline-comment-style */
+
 // TODO [2200-12-25]: Too long... Can you feel it?
 
 // TODO (SomeUser) [2200-12-12]: You can add something before the arguments.

--- a/test/fixtures/unicorn/throw-new-error.fail.ts
+++ b/test/fixtures/unicorn/throw-new-error.fail.ts
@@ -1,5 +1,5 @@
 /* eslint-disable new-cap */
-/* eslint-disable padding-line-between-statements */
+/* eslint-disable @stylistic/padding-line-between-statements */
 /* eslint-disable unicorn/new-for-builtins */
 
 throw Error('unicorn');

--- a/test/fixtures/unicorn/throw-new-error.pass.ts
+++ b/test/fixtures/unicorn/throw-new-error.pass.ts
@@ -1,4 +1,4 @@
-/* eslint-disable padding-line-between-statements */
+/* eslint-disable @stylistic/padding-line-between-statements */
 /* eslint-disable unicorn/error-message */
 
 throw new Error();

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -64,7 +64,7 @@ const ruleSetPrefix: Record<keyof typeof configuredRules, string | null> = {
   import: 'import',
   jest: 'jest',
   simpleImportSort: 'simple-import-sort',
-  stylistic: null,
+  stylistic: '@stylistic',
   typescriptEslint: '@typescript-eslint',
   unicorn: 'unicorn',
 };
@@ -74,10 +74,6 @@ const fixtureFilePath = (ruleSet: string): string => {
 
   if (ruleSet === 'eslint') {
     return `${BASE_PATH}/eslint/`;
-  }
-
-  if (ruleSet === 'stylistic') {
-    return `${BASE_PATH}/@stylistic/`;
   }
 
   return `${BASE_PATH}`;
@@ -221,8 +217,8 @@ describe.each(Object.keys(configuredRules))(
           });
 
           expect(result.warningCount).toBe(0);
-          expect(result.errorCount).toBeGreaterThan(0);
           expect(result.messages).toMatchSnapshot();
+          expect(result.errorCount).toBeGreaterThan(0);
         });
       },
     );


### PR DESCRIPTION
eslint-config-prettier overrides a whole bunch of stylistic rules, especially max-len which we don't want. I opted to move the stylistic rule under eslint-config-prettier. It's a little risky as there's a small chance that what prettier rewrites, creates a conflict with eslint. But I'm pretty sure that's not the case here, I double checked. If it does happen though we'll just come back here and resolve the conflicts.

I really prefer to have the max-len rule working correctly, and I couldn't find another way.