### PR TITLE
ci: set timeout-minutes for test step

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -55,3 +55,4 @@ jobs:
           - 20
           - 22
           - 24
+    timeout-minutes: 2


### PR DESCRIPTION
Noticed this accidentally, somehow [this PR](https://github.com/ridedott/eslint-config/pull/2700) gets tests stuck, and we don't have a timeout set for the Test step in CI 🫠 Crazy that the default is 6 hours (I guess makes sense from GitHub's money-making perspective), and apparently there's no way to set some kind of default [on organization-level either](https://github.com/orgs/community/discussions/14834).