### PR TITLE
chore: configure dependabot cooldown option

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,8 @@ updates:
     package-ecosystem: github-actions
     schedule:
       interval: daily
+    cooldown:
+      default-days: 30
   - allow:
       - dependency-type: direct
     commit-message:
@@ -24,4 +26,6 @@ updates:
     package-ecosystem: npm
     schedule:
       interval: daily
+    cooldown:
+      default-days: 30
     versioning-strategy: increase


### PR DESCRIPTION
Dependabot has this new `cooldown` option since July 2025. Prevent it from updating the packages right after release, instead waiting for 30 days.

No particular reason for 30 specifically, just that we don't need very frequent updates anyway.