### PR TITLE
feat enable consistent-type-imports rule again

### DIFF
--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -10,8 +10,7 @@ export default [
       // Does not make it possible to define recursive types.
       '@typescript-eslint/consistent-indexed-object-style': 'off',
       '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
-      // Conflicts with simple-import-sort/sort.
-      '@typescript-eslint/consistent-type-imports': 'off',
+      '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/explicit-function-return-type': [
         'error',
         { allowTypedFunctionExpressions: false },


### PR DESCRIPTION
### Context

It appears that whatever conflict there was, is no longer the case. I know this will probably give a lot of errors, but I prefer the consistency of this and it should be trivial to fix with `--fix`.