### PR TITLE
fix: move @eslint/js from devDependencies to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.1",
+        "@eslint/js": "^10.0.1",
         "@stylistic/eslint-plugin": "^5.10.0",
         "@vitest/eslint-plugin": "^1.6.17",
         "eslint-config-prettier": "^10.1.8",
@@ -25,7 +26,6 @@
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",
         "@commitlint/config-conventional": "^20.5.0",
-        "@eslint/js": "^10.0.1",
         "@types/eslint": "^9.6.1",
         "@types/node": "^22.19.17",
         "commitizen": "^4.3.1",
@@ -976,7 +976,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
       "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -11265,7 +11264,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
       "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
-      "dev": true,
       "requires": {}
     },
     "@eslint/object-schema": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     }
   },
   "dependencies": {
+    "@eslint/js": "^10.0.1",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.7.1",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@vitest/eslint-plugin": "^1.6.17",
@@ -22,7 +23,6 @@
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
-    "@eslint/js": "^10.0.1",
     "@types/eslint": "^9.6.1",
     "@types/node": "^22.19.17",
     "commitizen": "^4.3.1",


### PR DESCRIPTION
This dependency is directly imported by files used by library consumers.