### PR TITLE
ci: migrate to Blacksmith runners

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -9,7 +9,7 @@ jobs:
   release:
     if: contains(github.event.commits[0].message, 'chore(release)') == false
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   format:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 2
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/merge-me.yaml
+++ b/.github/workflows/merge-me.yaml
@@ -11,7 +11,7 @@ jobs:
   merge-me:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Merge me!
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Merge me!
         uses: ridedott/merge-me-action@master


### PR DESCRIPTION
Migrates CI jobs from GitHub-hosted runners to Blacksmith.

Mapping:
- ubuntu-latest -> blacksmith-2vcpu-ubuntu-2404 (heavier/longer jobs e.g. lint/test/build -> blacksmith-4vcpu-ubuntu-2404)
- ubuntu-latest-cpuN -> blacksmith-Nvcpu-ubuntu-2404

Only runs-on lines changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)